### PR TITLE
Feature/tls reject unauthorized

### DIFF
--- a/bin/vk-tunnel
+++ b/bin/vk-tunnel
@@ -200,7 +200,7 @@ function parseOptions() {
         process.env.PROXY_HTTP_PROTO = value;
         break;
       case '--insecure':
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = value ? 0 : 1;
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = value === '1' ? '0' : '1';
         break;
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vkontakte/vk-tunnel",
   "license": "MIT",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "bin": {
     "vk-tunnel": "./bin/vk-tunnel"
   },


### PR DESCRIPTION
Заметил,  что при любом не пустом значении `--insecure` (будь то `0` или `1`), значение `NODE_TLS_REJECT_UNAUTHORIZED` всегда будет `0`, потому что в данный момент проверка на value некорректна. Переписал так, чтобы была зависимость от этого значения, причем по умолчанию (когда `--insecure` не указан),  `NODE_TLS_REJECT_UNAUTHORIZED` = `1`. То есть проверка сертификата обязательна